### PR TITLE
chore: Enable arm64 build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,7 @@ endif
 
 ifeq ($(detected_OS),Darwin)
  LIB_EXT := dylib
- ifeq ("$(shell sysctl -nq hw.optional.arm64)","1")
-  # Building on M1 is still not supported, so in the meantime we crosscompile to amd64
-  FORCE_ARCH ?= amd64
-  CGOFLAGS=CGO_ENABLED=1 GOOS=darwin GOARCH=$(FORCE_ARCH)
- endif
+ CGOFLAGS := CGO_ENABLED=1 GOOS=darwin
 else ifeq ($(detected_OS),Windows)
  LIB_EXT:= dll
  LIBKEYCARD_EXT := dll


### PR DESCRIPTION
Removing the `FORCED_ARCH` flag as it's not needed.
The build can be configured from `make` command:
`make build-lib CGOFLAGS="CGO_ENABLED=1 GOOS=darwin GOARCH=amd64"`