### PR TITLE
fix: use exclusive connection, graceful disconnect and release

### DIFF
--- a/internal/readers_states.go
+++ b/internal/readers_states.go
@@ -21,7 +21,7 @@ func (rs ReadersStates) Update() {
 
 func (rs ReadersStates) ReaderWithCardIndex() (int, bool) {
 	for i := range rs {
-		if rs[i].EventState&scard.StatePresent == 0 {
+		if rs[i].EventState&scard.StatePresent == 0 || rs[i].EventState&scard.StateExclusive != 0 {
 			continue
 		}
 


### PR DESCRIPTION
Here's the main change:
https://github.com/keycard-tech/status-keycard-go/blob/d0608987aa534bcde9df4a6b5a5172ccd56a41f5/internal/keycard_context_v2.go#L220

Use `scard.ShareExclusive` connection instead of shared.
This is important, especially in case of Session API, as it requires no other applications to use the keycard during a session.

From the other side, the new code will also ignore any cards that are already busy by other apps:
https://github.com/keycard-tech/status-keycard-go/blob/d0608987aa534bcde9df4a6b5a5172ccd56a41f5/internal/readers_states.go#L24-L26

Tested with `status-desktop` that tries to find a keycard while an exclusive session is running. 
Note that after calling `Stop`, the keycard is automatically disconnected by Session API and is found by `status-deskop`.

https://github.com/user-attachments/assets/fb2da26c-dde0-4f98-993e-0eb75281d423