### PR TITLE
chore: switch back to go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/status-im/status-keycard-go
 
-go 1.22
+go 1.21
 
 require (
 	github.com/ebfe/scard v0.0.0-20241214075232-7af069cabc25


### PR DESCRIPTION
Revert back the minimum to Go 1.21 for now, because status-desktop CI is not yet migrated to Go 1.22.
I'll keep the CI here on 1.22 though, doesn't really matter.