### PR TITLE
feat: ResetAPI endpoint

### DIFF
--- a/shared/api_flow.go
+++ b/shared/api_flow.go
@@ -7,10 +7,8 @@ import "C"
 import (
 	"encoding/json"
 	"errors"
-	"unsafe"
 
 	"github.com/status-im/status-keycard-go/pkg/flow"
-	"github.com/status-im/status-keycard-go/signal"
 )
 
 var (
@@ -90,16 +88,6 @@ func KeycardCancelFlow() *C.char {
 
 	err := globalFlow.Cancel()
 	return retErr(err)
-}
-
-//export Free
-func Free(param unsafe.Pointer) {
-	C.free(param)
-}
-
-//export KeycardSetSignalEventCallback
-func KeycardSetSignalEventCallback(cb unsafe.Pointer) {
-	signal.KeycardSetSignalEventCallback(cb)
 }
 
 //export MockedLibRegisterKeycard

--- a/shared/main.go
+++ b/shared/main.go
@@ -1,6 +1,15 @@
 package main
 
-import "errors"
+// #cgo LDFLAGS: -shared
+// #include <stdlib.h>
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+
+	"github.com/status-im/status-keycard-go/signal"
+)
 
 func main() {}
 
@@ -27,4 +36,20 @@ func checkAPIMutualExclusion(requestedAPI api) error {
 	}
 
 	return nil
+}
+
+//export KeycardSetSignalEventCallback
+func KeycardSetSignalEventCallback(cb unsafe.Pointer) {
+	signal.KeycardSetSignalEventCallback(cb)
+}
+
+//export ResetAPI
+func ResetAPI() {
+	globalFlow = nil
+	globalRPCServer = nil
+}
+
+//export Free
+func Free(param unsafe.Pointer) {
+	C.free(param)
 }


### PR DESCRIPTION
Required to fix https://github.com/status-im/status-desktop/issues/17226

# Description

Because for now we use both `flow` and `session` APIs, we need an ability to switch between them. `ResetAPI` enables this.

Also moved common methods (`KeycardSetSignalEventCallback` and `Free`) to the common file.