### PR TITLE
feat: better authorize response

### DIFF
--- a/internal/keycard_context_v2.go
+++ b/internal/keycard_context_v2.go
@@ -575,7 +575,6 @@ func (kc *KeycardContextV2) VerifyPIN(pin string) (err error, authorized bool) {
 	}
 
 	defer func() {
-		authorized := err == nil && authorized
 		kc.onAuthorizeInteractions(authorized)
 	}()
 

--- a/internal/keycard_context_v2.go
+++ b/internal/keycard_context_v2.go
@@ -500,6 +500,10 @@ func (kc *KeycardContextV2) selectApplet() (*ApplicationInfoV2, error) {
 }
 
 func (kc *KeycardContextV2) updateApplicationStatus() error {
+	if err := kc.keycardInitialized(); err != nil {
+		return err
+	}
+
 	appStatus, err := kc.cmdSet.GetStatusApplication()
 	kc.status.AppStatus = ToAppStatus(appStatus)
 

--- a/pkg/session/service.go
+++ b/pkg/session/service.go
@@ -96,8 +96,8 @@ func (s *KeycardService) Authorize(args *AuthorizeRequest, reply *AuthorizeRespo
 		return errKeycardServiceNotStarted
 	}
 
-	err := s.keycardContext.VerifyPIN(args.PIN)
-	reply.Authorized = err == nil
+	err, authorized := s.keycardContext.VerifyPIN(args.PIN)
+	reply.Authorized = authorized
 	return err
 }
 


### PR DESCRIPTION
1. Properly separate possible results:
- `authorized` - was the PIN correct or not
- `error` - some error occurred (connection error, "wrong pin" is not considered an error)
2. Check if the keycard is connected during `updateApplicationStatus` to prevent panic.