### PR TITLE
fix: crash on stop

### DIFF
--- a/internal/keycard_context_v2.go
+++ b/internal/keycard_context_v2.go
@@ -468,8 +468,6 @@ func (kc *KeycardContextV2) Stop() {
 		}
 	}
 
-	kc.KeycardContext.Stop()
-
 	if kc.shutdown != nil {
 		kc.shutdown()
 	}


### PR DESCRIPTION
Fixes the crash that was occurring when attempting to close a `nil` channel

<details>
<summary>Log</summary>

```
DBG 2025-02-26 22:25:03.687Z NewBE_callPrivateRPC                       topics="rpc" tid=26264101 file=core.nim:27 rpc_method=accounts_getKeypairByKeyUID
DBG 2025-02-26 22:25:03.918Z [threadpool task thread] initiating task   topics="task-threadpool" tid=26264114 file=threadpool.nim:57 messageType=SaveOrUpdateKeycardTaskArg:ObjectType threadid=26264114
DBG 2025-02-26 22:25:03.918Z NewBE_callPrivateRPC                       topics="rpc" tid=26264114 file=core.nim:27 rpc_method=accounts_saveOrUpdateKeycard
panic: close of nil channel

goroutine 17 [running, locked to thread]:
github.com/status-im/status-keycard-go/internal.(*KeycardContext).Stop(...)
	/Users/jenkins/workspace/s_macos_aarch64_package_PR-17285/vendor/status-keycard-go/internal/keycard_context.go:144
github.com/status-im/status-keycard-go/internal.(*KeycardContextV2).Stop(0x240003d8000)
	/Users/jenkins/workspace/s_macos_aarch64_package_PR-17285/vendor/status-keycard-go/internal/keycard_context_v2.go:471 +0x134
github.com/status-im/status-keycard-go/pkg/session.(*KeycardService).Stop(0x106916ab0, 0x1?, 0x0?)
	/Users/jenkins/workspace/s_macos_aarch64_package_PR-17285/vendor/status-keycard-go/pkg/session/service.go:63 +0x2c
reflect.Value.call({0x24000128240?, 0x240001181f0?, 0x240000bfac8?}, {0x1064eedd4, 0x4}, {0x240000bfbd8, 0x3, 0x106453af8?})
	/usr/local/go/src/reflect/value.go:596 +0x970
reflect.Value.Call({0x24000128240?, 0x240001181f0?, 0x10697ef00?}, {0x240000bfbd8?, 0x240000bfb58?, 0x1061b6da8?})
	/usr/local/go/src/reflect/value.go:380 +0x94
github.com/gorilla/rpc.(*Server).ServeHTTP(0x24000110030, {0x10666e610, 0x24000120900}, 0x24000114480)
	/Users/jenkins/go/pkg/mod/github.com/gorilla/rpc@v1.2.1/server.go:226 +0x4bc
main.KeycardCallRPC(0x1065dff01?)
	/Users/jenkins/workspace/s_macos_aarch64_package_PR-17285/vendor/status-keycard-go/shared/api_session.go:63 +0x1e0
SIGABRT: Abnormal termination.
```