### PR TITLE
fix: handle specific error cases in KeycardContextV2

### DIFF
--- a/internal/keycard_context_v2.go
+++ b/internal/keycard_context_v2.go
@@ -304,6 +304,10 @@ func (kc *KeycardContextV2) watchActiveReader(ctx context.Context, activeReader 
 	for {
 		err := kc.cardCtx.GetStatusChange(readersStates, zeroTimeout)
 
+		if err == scard.ErrUnknownReader {
+			break
+		}
+
 		if err != nil && err != scard.ErrTimeout {
 			kc.logger.Error("failed to get status change", zap.Error(err))
 			return
@@ -335,7 +339,7 @@ func (kc *KeycardContextV2) watchActiveReader(ctx context.Context, activeReader 
 func (kc *KeycardContextV2) getCurrentReadersState() (ReadersStates, error) {
 	readers, err := kc.cardCtx.ListReaders()
 	err = kc.simulateError(err, simulatedListReadersError)
-	if err != nil {
+	if err != nil && err != scard.ErrNoReadersAvailable {
 		return nil, err
 	}
 


### PR DESCRIPTION
On Linux the behaviour of library is a bit different, so we need to handle some specific error cases to make it work.
Tested on Linux and MacOS.